### PR TITLE
New Icon implementation proposal

### DIFF
--- a/atoms/NewIcon/NewIcon.js
+++ b/atoms/NewIcon/NewIcon.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import { iconsDictionary, mapSize } from './helpers'
+
+import styles from './NewIcon.module.css'
+
+const NewIcon = ({
+  iconName,
+  size,
+  hasBackground,
+  classes,
+  iconStyles,
+  svgTitle,
+}) => {
+  const svgRender = iconsDictionary[iconName] || iconsDictionary.default
+  const mappedSize = mapSize(size)
+
+  return (
+    <div
+      padding={mappedSize}
+      className={classNames(styles['icon-container'], {
+        classes: classes,
+        [styles['has-background']]: hasBackground,
+      })}
+    >
+      <svg
+        viewBox={svgRender.viewBox}
+        className={classes}
+        style={iconStyles}
+        title={svgTitle}
+        xmlns="http://www.w3.org/2000/svg"
+        width={mappedSize}
+        height={mappedSize}
+      >
+        {svgRender.svg}
+      </svg>
+    </div>
+  )
+}
+
+NewIcon.propTypes = {
+  iconName: PropTypes.string.isRequired,
+  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+  hasBackground: PropTypes.bool,
+  classes: PropTypes.string,
+  iconStyles: PropTypes.object,
+  svgTitle: PropTypes.string,
+}
+
+NewIcon.defaultProps = {
+  size: 'md',
+  hasBackground: false,
+}
+
+export default NewIcon

--- a/atoms/NewIcon/NewIcon.module.css
+++ b/atoms/NewIcon/NewIcon.module.css
@@ -1,0 +1,12 @@
+.icon-container { 
+  box-sizing: content-box;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+}
+
+.has-background {
+  background: var(--color-primary-highlight);
+  border-radius: var(--border-radius-full);
+}

--- a/atoms/NewIcon/helpers.js
+++ b/atoms/NewIcon/helpers.js
@@ -1,0 +1,51 @@
+import React from 'react'
+
+class Icon {
+  constructor(viewBox, svg) {
+    this.viewBox = viewBox
+    this.svg = <>{svg}</>
+  }
+}
+
+export const iconsDictionary = {
+  'arrow-right': new Icon(
+    '0 0 19 20',
+    (
+      <>
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M8.65792 19.316L7.34192 18L15.6849 9.658L7.34192 1.316L8.65792 0L18.3149 9.658L8.65792 19.316Z"
+          fill="#987CE6"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M0 8.65796H17V10.658H0V8.65796Z"
+          fill="#987CE6"
+        />
+      </>
+    )
+  ),
+  'angle-down': new Icon(
+    '0 0 15 9',
+    (
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M7.82633 8.70623L0.882568 1.54063L1.89405 0.496826L7.82633 6.61863L13.7586 0.496826L14.7701 1.54063L7.82633 8.70623Z"
+        fill="#46596F"
+      />
+    )
+  ),
+  default: null,
+}
+
+const iconSize = {
+  sm: 12,
+  md: 16,
+  lg: 24,
+  xl: 32,
+}
+
+export const mapSize = (size) => iconSize[size]

--- a/atoms/NewIcon/index.js
+++ b/atoms/NewIcon/index.js
@@ -1,0 +1,1 @@
+export { default } from './NewIcon'

--- a/stories/atoms/NewIcon.stories.js
+++ b/stories/atoms/NewIcon.stories.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import NewIcon from '../../atoms/NewIcon'
+
+export default {
+  title: 'Atoms/NewIcon',
+  component: NewIcon,
+}
+
+export const ArrowRight = () => (
+  <>
+    <NewIcon iconName="arrow-right" size="sm" />
+    <NewIcon iconName="arrow-right" size="md" />
+    <NewIcon iconName="arrow-right" size="lg" />
+    <NewIcon iconName="arrow-right" size="xl" />
+  </>
+)
+export const AngleDown = () => (
+  <>
+    <NewIcon iconName="angle-down" size="sm" />
+    <NewIcon iconName="angle-down" size="md" />
+    <NewIcon iconName="angle-down" size="lg" />
+    <NewIcon iconName="angle-down" size="xl" />
+  </>
+)
+export const HasBackground = () => (
+  <>
+    <NewIcon iconName="angle-down" size="sm" hasBackground />
+    <NewIcon iconName="angle-down" size="md" hasBackground />
+    <NewIcon iconName="angle-down" size="lg" hasBackground />
+    <NewIcon iconName="angle-down" size="xl" hasBackground />
+  </>
+)


### PR DESCRIPTION
Esta es una propuesta para el componente Icon, el actual tiene la limitación de que usa `<img />` y de esa forma no se pueden cambiar estilos propios del svg

El archivo de **diccionario de iconos**, que esta en **helpers**, es el que me deja en duda. Originalmente tenia el jsx con el svg del icono en una sola linea, pero al prettier no le gusta mucho eso y desactivarlo en todo el archivo no me cuadraba mucho. El pr tiene actualmente el archivo formateado de la forma en la que lo acepta prettier
