### PR TITLE
chore: upgrade to React 19.2, Storybook 10.0.1, and Node 24

### DIFF
--- a/hocs/withStyles.js
+++ b/hocs/withStyles.js
@@ -5,7 +5,10 @@ const withStyles = (styles) => (WrappedComponent) => {
   const WithStylesComponent = (props) => {
     const allProps = { ...WrappedComponent.defaultProps, ...props }
     return (
-      <WrappedComponent getStyles={getClasses(styles)(allProps)} {...props} />
+      <WrappedComponent
+        {...allProps}
+        getStyles={getClasses(styles)(allProps)}
+      />
     )
   }
 

--- a/storybook.snapx
+++ b/storybook.snapx
@@ -236,9 +236,12 @@ exports[`[ storybook ] > [ Atoms/Check ] > should render Checked 1`] = `
 <DocumentFragment>
   <div
     class="_icon_e83468 _color-muted_e83468 _size-md_e83468 _background-transparent_e83468 _is-clickable_e83468"
+    style="width: 35px; height: 35px;"
   >
     <svg
+      height="35"
       viewBox="5 1 20 20"
+      width="35"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -1620,9 +1623,12 @@ exports[`[ storybook ] > [ Atoms/Modal ] > should render SecondaryAction 1`] = `
       >
         <div
           class="_icon_e83468 _color-inverted_e83468 _size-md_e83468 _background-muted_e83468 _is-clickable_e83468"
+          style="width: 35px; height: 35px;"
         >
           <svg
+            height="35"
             viewBox="5 1 20 20"
+            width="35"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -2070,7 +2076,7 @@ exports[`[ storybook ] > [ Molecules/Accordion ] > should render AddonAppend 1`]
       </div>
       <div
         class="_spacer_5847bc _horizontal_5847bc"
-        style="width: 15px;"
+        style="height: 100%; max-height: auto; width: 15px;"
       />
       <p
         class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -2117,7 +2123,7 @@ exports[`[ storybook ] > [ Molecules/Accordion ] > should render AddonPrepend 1`
       </div>
       <div
         class="_spacer_5847bc _horizontal_5847bc"
-        style="width: 15px;"
+        style="height: 100%; max-height: auto; width: 15px;"
       />
       Dare Erebor forgive most.
       <p
@@ -2164,7 +2170,7 @@ exports[`[ storybook ] > [ Molecules/Accordion ] > should render Default 1`] = `
       </div>
       <div
         class="_spacer_5847bc _horizontal_5847bc"
-        style="width: 15px;"
+        style="height: 100%; max-height: auto; width: 15px;"
       />
       <p
         class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -2191,9 +2197,12 @@ exports[`[ storybook ] > [ Molecules/AddButton ] > should render Default 1`] = `
   >
     <div
       class="_icon_e83468 _color-base_e83468 _size-md_e83468 _background-highlight_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 20 20"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2215,7 +2224,7 @@ exports[`[ storybook ] > [ Molecules/AddButton ] > should render Default 1`] = `
     </div>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 15px;"
+      style="height: 100%; max-height: auto; width: 15px;"
     />
     <p
       class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -2266,7 +2275,7 @@ exports[`[ storybook ] > [ Molecules/AddButton ] > should render HelpText 1`] = 
       </p>
       <div
         class="_spacer_5847bc _horizontal_5847bc"
-        style="width: 15px;"
+        style="height: 100%; max-height: auto; width: 15px;"
       />
     </div>
   </div>
@@ -2300,9 +2309,12 @@ exports[`[ storybook ] > [ Molecules/AddButton ] > should render Types 1`] = `
   >
     <div
       class="_icon_e83468 _color-base_e83468 _size-md_e83468 _background-highlight_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 20 20"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2324,7 +2336,7 @@ exports[`[ storybook ] > [ Molecules/AddButton ] > should render Types 1`] = `
     </div>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 15px;"
+      style="height: 100%; max-height: auto; width: 15px;"
     />
     <p
       class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -2338,9 +2350,12 @@ exports[`[ storybook ] > [ Molecules/AddButton ] > should render Types 1`] = `
   >
     <div
       class="_icon_e83468 _color-highlight_e83468 _size-md_e83468 _background-undefined_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 20 20"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2362,7 +2377,7 @@ exports[`[ storybook ] > [ Molecules/AddButton ] > should render Types 1`] = `
     </div>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 15px;"
+      style="height: 100%; max-height: auto; width: 15px;"
     />
     <p
       class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -2385,13 +2400,16 @@ exports[`[ storybook ] > [ Molecules/ButtonIcon ] > should render Default 1`] = 
     </h1>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 5px;"
+      style="height: 100%; max-height: auto; width: 5px;"
     />
     <div
       class="_icon_e83468 _color-primary_e83468 _size-md_e83468 _background-transparent_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 19 20"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2422,13 +2440,16 @@ exports[`[ storybook ] > [ Molecules/ButtonIcon ] > should render Types 1`] = `
     </h1>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 5px;"
+      style="height: 100%; max-height: auto; width: 5px;"
     />
     <div
       class="_icon_e83468 _color-inverted_e83468 _size-md_e83468 _background-transparent_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 19 20"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2454,13 +2475,16 @@ exports[`[ storybook ] > [ Molecules/ButtonIcon ] > should render Types 1`] = `
     </h1>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 5px;"
+      style="height: 100%; max-height: auto; width: 5px;"
     />
     <div
       class="_icon_e83468 _color-primary_e83468 _size-md_e83468 _background-transparent_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 19 20"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2486,9 +2510,12 @@ exports[`[ storybook ] > [ Molecules/Dropdown ] > should render Default 1`] = `
   >
     <div
       class="_dropdown-icon_e83468 _icon_e83468 _color-base_e83468 _size-md_e83468 _background-highlight_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 15 9"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2523,9 +2550,12 @@ exports[`[ storybook ] > [ Molecules/Dropdown ] > should render Inline 1`] = `
   >
     <div
       class="_dropdown-icon_e83468 _icon_e83468 _color-base_e83468 _size-md_e83468 _background-highlight_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 15 9"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2560,9 +2590,12 @@ exports[`[ storybook ] > [ Molecules/Dropdown ] > should render Value 1`] = `
   >
     <div
       class="_dropdown-icon_e83468 _icon_e83468 _color-base_e83468 _size-md_e83468 _background-highlight_e83468"
+      style="width: 35px; height: 35px;"
     >
       <svg
+        height="35"
         viewBox="0 0 15 9"
+        width="35"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2617,7 +2650,7 @@ exports[`[ storybook ] > [ Molecules/Error ] > should render Default 1`] = `
     </div>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 15px;"
+      style="height: 100%; max-height: auto; width: 15px;"
     />
     <div>
       <p
@@ -2657,7 +2690,7 @@ exports[`[ storybook ] > [ Molecules/Error ] > should render Title 1`] = `
     </div>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 15px;"
+      style="height: 100%; max-height: auto; width: 15px;"
     />
     <div>
       <h1
@@ -2792,7 +2825,7 @@ exports[`[ storybook ] > [ Molecules/IconLabel ] > should render Horizontal 1`] 
     </div>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 5px;"
+      style="height: 100%; max-height: auto; width: 5px;"
     />
     <p
       class="_paragraph_eedbfe _color-base_eedbfe _size-xs_eedbfe _weight-normal_eedbfe _is-inline_eedbfe"
@@ -2836,7 +2869,7 @@ exports[`[ storybook ] > [ Molecules/LoadingError ] > should render Error 1`] = 
     </div>
     <div
       class="_spacer_5847bc _horizontal_5847bc"
-      style="width: 15px;"
+      style="height: 100%; max-height: auto; width: 15px;"
     />
     <div>
       <p
@@ -2880,9 +2913,12 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Checked 1`] = `
           >
             <div
               class="_icon_e83468 _color-muted_e83468 _size-md_e83468 _background-transparent_e83468 _is-clickable_e83468"
+              style="width: 35px; height: 35px;"
             >
               <svg
+                height="35"
                 viewBox="5 1 20 20"
+                width="35"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -2900,7 +2936,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Checked 1`] = `
           </div>
           <div
             class="_spacer_5847bc _horizontal_5847bc"
-            style="width: 5px;"
+            style="height: 100%; max-height: auto; width: 5px;"
           />
           <p
             class="_paragraph_eedbfe _color-muted_eedbfe _size-md_eedbfe _weight-medium_eedbfe _is-striked_eedbfe"
@@ -2910,7 +2946,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Checked 1`] = `
         </div>
         <div
           class="_spacer_5847bc _horizontal_5847bc"
-          style="width: 15px;"
+          style="height: 100%; max-height: auto; width: 15px;"
         />
         <div
           class="_icon_e83468 _color-base_e83468 _size-sm_e83468 _background-inverted_e83468 _is-clickable_e83468"
@@ -2983,7 +3019,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Default 1`] = `
           </div>
           <div
             class="_spacer_5847bc _horizontal_5847bc"
-            style="width: 5px;"
+            style="height: 100%; max-height: auto; width: 5px;"
           />
           <p
             class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -2993,7 +3029,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Default 1`] = `
         </div>
         <div
           class="_spacer_5847bc _horizontal_5847bc"
-          style="width: 15px;"
+          style="height: 100%; max-height: auto; width: 15px;"
         />
         <div
           class="_icon_e83468 _color-base_e83468 _size-sm_e83468 _background-inverted_e83468 _is-clickable_e83468"
@@ -3066,7 +3102,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Long 1`] = `
           </div>
           <div
             class="_spacer_5847bc _horizontal_5847bc"
-            style="width: 5px;"
+            style="height: 100%; max-height: auto; width: 5px;"
           />
           <p
             class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -3076,7 +3112,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Long 1`] = `
         </div>
         <div
           class="_spacer_5847bc _horizontal_5847bc"
-          style="width: 15px;"
+          style="height: 100%; max-height: auto; width: 15px;"
         />
         <div
           class="_icon_e83468 _color-base_e83468 _size-sm_e83468 _background-inverted_e83468 _is-clickable_e83468"
@@ -3157,7 +3193,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Pending 1`] = `
           </div>
           <div
             class="_spacer_5847bc _horizontal_5847bc"
-            style="width: 5px;"
+            style="height: 100%; max-height: auto; width: 5px;"
           />
           <p
             class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -3167,7 +3203,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Pending 1`] = `
         </div>
         <div
           class="_spacer_5847bc _horizontal_5847bc"
-          style="width: 15px;"
+          style="height: 100%; max-height: auto; width: 15px;"
         />
         <div
           class="_icon_e83468 _color-base_e83468 _size-sm_e83468 _background-inverted_e83468 _is-clickable_e83468"
@@ -3248,7 +3284,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render PendingTypes 1`] = `
           </div>
           <div
             class="_spacer_5847bc _horizontal_5847bc"
-            style="width: 5px;"
+            style="height: 100%; max-height: auto; width: 5px;"
           />
           <p
             class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -3258,7 +3294,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render PendingTypes 1`] = `
         </div>
         <div
           class="_spacer_5847bc _horizontal_5847bc"
-          style="width: 15px;"
+          style="height: 100%; max-height: auto; width: 15px;"
         />
         <div
           class="_icon_e83468 _color-base_e83468 _size-sm_e83468 _background-inverted_e83468 _is-clickable_e83468"
@@ -3334,7 +3370,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render PendingTypes 1`] = `
           </div>
           <div
             class="_spacer_5847bc _horizontal_5847bc"
-            style="width: 5px;"
+            style="height: 100%; max-height: auto; width: 5px;"
           />
           <p
             class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -3344,7 +3380,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render PendingTypes 1`] = `
         </div>
         <div
           class="_spacer_5847bc _horizontal_5847bc"
-          style="width: 15px;"
+          style="height: 100%; max-height: auto; width: 15px;"
         />
         <div
           class="_icon_e83468 _color-base_e83468 _size-sm_e83468 _background-inverted_e83468 _is-clickable_e83468"
@@ -3417,7 +3453,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Types 1`] = `
           </div>
           <div
             class="_spacer_5847bc _horizontal_5847bc"
-            style="width: 5px;"
+            style="height: 100%; max-height: auto; width: 5px;"
           />
           <p
             class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -3427,7 +3463,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Types 1`] = `
         </div>
         <div
           class="_spacer_5847bc _horizontal_5847bc"
-          style="width: 15px;"
+          style="height: 100%; max-height: auto; width: 15px;"
         />
         <div
           class="_icon_e83468 _color-base_e83468 _size-sm_e83468 _background-inverted_e83468 _is-clickable_e83468"
@@ -3495,7 +3531,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Types 1`] = `
           </div>
           <div
             class="_spacer_5847bc _horizontal_5847bc"
-            style="width: 5px;"
+            style="height: 100%; max-height: auto; width: 5px;"
           />
           <p
             class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"
@@ -3505,7 +3541,7 @@ exports[`[ storybook ] > [ Molecules/Task ] > should render Types 1`] = `
         </div>
         <div
           class="_spacer_5847bc _horizontal_5847bc"
-          style="width: 15px;"
+          style="height: 100%; max-height: auto; width: 15px;"
         />
         <div
           class="_icon_e83468 _color-base_e83468 _size-sm_e83468 _background-inverted_e83468 _is-clickable_e83468"
@@ -3613,7 +3649,7 @@ exports[`[ storybook ] > [ Molecules/TaskCounter ] > should render Toggleable 1`
       </div>
       <div
         class="_spacer_5847bc _horizontal_5847bc"
-        style="width: 15px;"
+        style="height: 100%; max-height: auto; width: 15px;"
       />
       <p
         class="_paragraph_eedbfe _color-base_eedbfe _size-md_eedbfe _weight-medium_eedbfe"

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,9 +27,12 @@ export default defineConfig({
   resolve: {
     alias: {
       // Force all packages to use the same React version (React 19)
-      'react': path.resolve(__dirname, './node_modules/react'),
+      react: path.resolve(__dirname, './node_modules/react'),
       'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
-      'react/jsx-runtime': path.resolve(__dirname, './node_modules/react/jsx-runtime'),
+      'react/jsx-runtime': path.resolve(
+        __dirname,
+        './node_modules/react/jsx-runtime',
+      ),
     },
   },
   css: {

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -5,7 +5,7 @@ const CONSOLE_LEVELS = ['debug', 'log', 'info', 'warn', 'error']
 
 // Notice that by default the levels will be ["error"]
 const allowedConsoleLevels = CONSOLE_LEVELS.slice(
-  CONSOLE_LEVELS.indexOf(process.env.CONSOLE_LEVEL)
+  CONSOLE_LEVELS.indexOf(process.env.CONSOLE_LEVEL),
 )
 
 global.console = CONSOLE_LEVELS.reduce((levels, level) => {


### PR DESCRIPTION
Major dependency upgrades following official migration guides:

- Upgrade React from 18.2.0 to 19.2.3
- Upgrade Storybook from 6.5.9 to 10.0.1
- Update Node requirement from >=16.13.2 to >=24.0.0
- Update all related dependencies to latest compatible versions

React 19 changes:
- Updated react, react-dom, react-is, react-test-renderer to 19.2.3
- Updated @testing-library/react to 16.1.0 for React 19 support
- Added @testing-library/dom 10.4.0 peer dependency
- Updated peerDependencies to use React ^19.2.3

Storybook 10 changes (ESM-only):
- Migrated from addon-essentials package (now integrated into core)
- Updated framework configuration to use @storybook/react-webpack5
- Updated CLI commands: storybook dev/build (replacing start-storybook/build-storybook)
- Updated composeStories import from @storybook/testing-react to @storybook/react
- Configured Jest to transform ESM packages (@storybook and storybook)

Other dependency updates:
- Babel packages: 7.28.5
- Jest: 29.7.0
- ESLint: 9.18.0
- Prettier: 3.4.2
- Commitlint: 20.3.0
- And various other supporting packages to latest versions

Note: Storybook snapshot tests have compatibility issues with React 19
that need further investigation. Core tests (28/28) pass successfully.

References:
- React 19 Upgrade Guide: https://react.dev/blog/2024/04/25/react-19-upgrade-guide
- Storybook 10 Migration: https://storybook.js.org/docs/releases/migration-guide