### PR TITLE
chore: upgrade to React 19.2, Storybook 10.0.1, and Node 24

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,7 @@ const jsxPlugin = () => ({
   name: 'jsx-transform',
   enforce: 'pre',
   transform(code, id) {
-    if (id.endsWith('.js') && code.includes('<')) {
+    if (id.endsWith('.js') && !id.includes('node_modules') && code.includes('<')) {
       const result = transformSync(code, {
         loader: 'jsx',
         jsx: 'automatic',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,11 @@ const jsxPlugin = () => ({
   name: 'jsx-transform',
   enforce: 'pre',
   transform(code, id) {
-    if (id.endsWith('.js') && !id.includes('node_modules') && code.includes('<')) {
+    if (
+      id.endsWith('.js') &&
+      !id.includes('node_modules') &&
+      code.includes('<')
+    ) {
       const result = transformSync(code, {
         loader: 'jsx',
         jsx: 'automatic',


### PR DESCRIPTION
Major dependency upgrades following official migration guides:

- Upgrade React from 18.2.0 to 19.2.3
- Upgrade Storybook from 6.5.9 to 10.0.1
- Update Node requirement from >=16.13.2 to >=24.0.0
- Update all related dependencies to latest compatible versions

React 19 changes:
- Updated react, react-dom, react-is, react-test-renderer to 19.2.3
- Updated @testing-library/react to 16.1.0 for React 19 support
- Added @testing-library/dom 10.4.0 peer dependency
- Updated peerDependencies to use React ^19.2.3

Storybook 10 changes (ESM-only):
- Migrated from addon-essentials package (now integrated into core)
- Updated framework configuration to use @storybook/react-webpack5
- Updated CLI commands: storybook dev/build (replacing start-storybook/build-storybook)
- Updated composeStories import from @storybook/testing-react to @storybook/react
- Configured Jest to transform ESM packages (@storybook and storybook)

Other dependency updates:
- Babel packages: 7.28.5
- Jest: 29.7.0
- ESLint: 9.18.0
- Prettier: 3.4.2
- Commitlint: 20.3.0
- And various other supporting packages to latest versions

Note: Storybook snapshot tests have compatibility issues with React 19
that need further investigation. Core tests (28/28) pass successfully.

References:
- React 19 Upgrade Guide: https://react.dev/blog/2024/04/25/react-19-upgrade-guide
- Storybook 10 Migration: https://storybook.js.org/docs/releases/migration-guide