### PR TITLE
Set storybook root container to full height

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
+
+<style>
+  #storybook-root {
+    height: 100%;
+  }
+</style>


### PR DESCRIPTION
## Summary
Updated the Storybook preview configuration to ensure the root container takes up the full available height.

## Changes
- Added a CSS style rule to `.storybook/preview-head.html` that sets `#storybook-root` to `height: 100%`
- This ensures the Storybook root element expands to fill the entire viewport height, improving layout consistency for stories

## Details
The change adds a simple style block to the Storybook preview head that makes the root container height-aware. This is useful for stories that need to utilize the full vertical space or have layout requirements that depend on the container being full height.

https://claude.ai/code/session_01Qq7CtpTrdXKUitw4Kshe43